### PR TITLE
RSpecをtravis-ciで実行できるようにする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ rvm:
 before_install: gem install bundler -v 1.16.1
 script:
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then bin/update; fi
+  - bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/rinkei/jipcode.svg?branch=master)](https://travis-ci.org/rinkei/jipcode)
+
 # Jipcode
 
 Jipcodeは郵便番号から住所を検索する機能を提供します。

--- a/spec/jipcode_spec.rb
+++ b/spec/jipcode_spec.rb
@@ -5,19 +5,19 @@ RSpec.describe Jipcode do
 
   describe '.locate' do
     before(:all) do
-      open("#{Jipcode::ZIPCODE_PATH}/xxx.csv", 'w') do |f|
-        f.write("xxx0001,HOGE県,hoge市,ほげ\nxxx0001,FUGA県,fuga市,ふが\nxxx0002,PIYO県,piyo市,ぴよ")
+      open("#{Jipcode::ZIPCODE_PATH}/000.csv", 'w') do |f|
+        f.write("0000001,HOGE県,hoge市,ほげ\n0000001,FUGA県,fuga市,ふが\n0000002,PIYO県,piyo市,ぴよ")
       end
     end
 
     after(:all) do
-      File.delete("#{Jipcode::ZIPCODE_PATH}/xxx.csv")
+      File.delete("#{Jipcode::ZIPCODE_PATH}/000.csv")
     end
 
     subject { Jipcode.locate(zipcode) }
 
     context '引数の郵便番号に対応する住所がない時' do
-      let(:zipcode) { 'xxx0000' }
+      let(:zipcode) { '0000000' }
 
       it '空配列を返す' do
         is_expected.to eq []
@@ -25,12 +25,12 @@ RSpec.describe Jipcode do
     end
 
     context '引数の郵便番号に対応する住所がある時' do
-      let(:zipcode) { 'xxx0001' }
+      let(:zipcode) { '0000001' }
 
       it '対応する住所を全て含む配列を返す' do
         is_expected.to eq [
-          { zipcode: 'xxx0001', prefecture: 'HOGE県', city: 'hoge市', town: 'ほげ' },
-          { zipcode: 'xxx0001', prefecture: 'FUGA県', city: 'fuga市', town: 'ふが' }
+          { zipcode: '0000001', prefecture: 'HOGE県', city: 'hoge市', town: 'ほげ' },
+          { zipcode: '0000001', prefecture: 'FUGA県', city: 'fuga市', town: 'ふが' }
         ]
       end
     end


### PR DESCRIPTION
## Before
053cb771e238e8f8e414a42534d4bdeb1ab17915 の変更でテストが失敗するようになっていたが、
`.travis.yml`の設定が正しくできていなかったため気づけなかった。

## After
`.travis.yml`で`rspec`を実行するようにし、CIでテストが落ちるのを確認する。
その上でテストを修正しCIを通るようにする。