### PR TITLE
Avoid using secret environment variables on Pull Requests from external contributors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,8 @@ language: ruby
 rvm:
   - 2.5.0
 before_install:
-  - openssl aes-256-cbc -K $encrypted_3597653ee3ea_key -iv $encrypted_3597653ee3ea_iv -in .travis_rsa.enc -out ~/.ssh/id_rsa -d
-  - chmod 600 ~/.ssh/id_rsa
-  - git remote set-url origin git@github.com:rinkei/jipcode.git
   - gem install bundler -v 1.16.1
 install: bundle install --jobs=3 --retry=3
 script:
-  - bin/update
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bin/update; fi
   - bundle exec rake spec

--- a/bin/update
+++ b/bin/update
@@ -20,5 +20,8 @@ if git commit -m `date "+%Y年%m月%d日現在の郵便番号データに更新"
   git add Gemfile.lock lib/jipcode/version.rb
   git commit -m "バージョンを`bundle exec bump current | sed -e "s/^\(.*: \)//"`に更新"
 
+  openssl aes-256-cbc -K $encrypted_3597653ee3ea_key -iv $encrypted_3597653ee3ea_iv -in .travis_rsa.enc -out ~/.ssh/id_rsa -d
+  chmod 600 ~/.ssh/id_rsa
+  git remote set-url origin git@github.com:rinkei/jipcode.git
   git push origin master
 fi


### PR DESCRIPTION
Encrypted variables or data are NOT available on Pull Requests from external contributors, which results in CI build failing:

```
$ openssl aes-256-cbc -K $encrypted_3597653ee3ea_key -iv $encrypted_3597653ee3ea_iv -in .travis_rsa.enc -out ~/.ssh/id_rsa -d
iv undefined
The command "openssl aes-256-cbc -K $encrypted_3597653ee3ea_key -iv $encrypted_3597653ee3ea_iv -in .travis_rsa.enc -out ~/.ssh/id_rsa -d" failed and exited with 1 during .
```
ref: https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions

`bin/update` seems to be expected to run only on monthly Travis cron jobs, so I moved the setup for `git push origin master` into `bin/update` including the environment variables and made it not to be run from external Pull Requests.