### PR TITLE
[Suggestion] use `match?` instead of `=~` when check valid zipcode

### DIFF
--- a/lib/jipcode.rb
+++ b/lib/jipcode.rb
@@ -8,7 +8,7 @@ module Jipcode
 
   def locate(zipcode, opt={})
     # 数字7桁以外の入力は受け付けない
-    return [] unless zipcode =~ /\A\d{7}?\z/
+    return [] unless zipcode&.match?(/\A\d{7}?\z/)
 
     # 上3桁にマッチするファイルが存在しなければ該当なし
     path = "#{ZIPCODE_PATH}/#{zipcode[0..2]}.csv"


### PR DESCRIPTION
Hello, this wonderful and useful gem developers 🤝
Because of Ruby 2.3 version is EOL since last march and I suppose we can use `match?` method now. As you know, match? method is much faster than `=~` and readable 😀
How do you think ?
[Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/)

<img width="446" alt="Screen Shot 2020-01-12 at 17 29 45" src="https://user-images.githubusercontent.com/40445689/72216187-47261780-3561-11ea-8741-1e0cbb620271.png">
