### PR TITLE
リリースを自動化する

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,3 +17,7 @@ jobs:
         bundler-cache: true
     - name: Run update
       run: bin/update
+    - name: Release
+      run: bundle exec rake release
+      env:
+        GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}


### PR DESCRIPTION
## Before
毎月の郵便番号データの更新で目視チェックを行ってから手動リリースをしていた。

## After
数年の目視チェックでほぼ問題が発生しなかったため、リリースを自動化する。
2023/07/01のリリースから自動化される。しばらくは自動リリースの直後に目視チェックを行う。

この方針の変更にあわせてメジャーバージョンアップを行う。