### PR TITLE
Github Actionsのcheckoutをv2からv4に更新

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         ruby-version: ['2.7', '3.0', '3.1']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/ により、10月の更新に失敗している。