### PR TITLE
Add dependency on csv gem because it will become bundled gem

### DIFF
--- a/jipcode.gemspec
+++ b/jipcode.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "csv"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Ruby 3.3 で bundler の下で jipcode を利用すると、warning が出るようになりました。
```
$ ruby -v
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [arm64-darwin23]

$ cat Gemfile
source "https://rubygems.org"

ruby "3.3.3"

gem "jipcode"

$ bundle exec ruby -rjipcode -e 'puts Jipcode.locate("8112414").first'
<HOME>/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/jipcode-3.0.12/lib/jipcode.rb:2: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of jipcode-3.0.12 to add csv into its gemspec.
{:zipcode=>"8112414", :prefecture=>"福岡県", :city=>"糟屋郡篠栗町", :town=>"和田"}
```

Ruby 3.4 では csv gem が default gem から bundled gem に変更されるため、bundler で利用する際は csv gem への依存関係を明示的に指定しなければならなくなります。
本 PR では gemspec で csv gem への依存関係を指定し、Ruby 3.3 で warning が出ないようにし、Ruby 3.4 でも動作するようにします。
see. https://gihyo.jp/article/2024/01/ruby3.3-bundled-gems