### PR TITLE
Ruby3.4でbundled gemsに変更されたgemへの依存をgemspecに明記

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,19 +2,25 @@ PATH
   remote: .
   specs:
     jipcode (3.1.23)
+      base64
+      bigdecimal
       csv
+      nkf
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
     bump (0.10.0)
     crack (0.4.5)
       rexml
     csv (3.2.8)
     diff-lcs (1.5.0)
     hashdiff (1.0.1)
+    nkf (0.2.0)
     public_suffix (5.0.1)
     rake (13.0.6)
     rexml (3.2.5)
@@ -40,6 +46,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/jipcode.gemspec
+++ b/jipcode.gemspec
@@ -22,6 +22,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "csv"
+  spec.add_dependency "nkf"
+  spec.add_dependency "base64"
+  spec.add_dependency "bigdecimal"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
gemspecの依存記載の不足により、Ruby3.4で動作できなくなっていた問題を解消する。