### PR TITLE
Ruby3.4でbundled gemsに変更されたgemへの依存をdevelopmentのみに変更

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,7 @@ PATH
   remote: .
   specs:
     jipcode (3.2.0)
-      base64
-      bigdecimal
       csv
-      nkf
 
 GEM
   remote: https://rubygems.org/
@@ -53,9 +50,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  base64
+  bigdecimal
   bump
   bundler
   jipcode!
+  nkf
   rake
   rspec
   rubyzip

--- a/jipcode.gemspec
+++ b/jipcode.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "csv"
-  spec.add_dependency "nkf"
-  spec.add_dependency "base64"
-  spec.add_dependency "bigdecimal"
+  spec.add_development_dependency "nkf"
+  spec.add_development_dependency "base64"
+  spec.add_development_dependency "bigdecimal"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
rake updateはdevelopmentのみで実行するはずなので、問題ないと思う。
ただ検証しようとしたらken_all.zipのURLが404になっててできない。
一旦こちらを試しにリリースして、404の方は別途対応する。