### PR TITLE
日本郵便の郵便番号データのURLの変更に対応

### DIFF
--- a/lib/jipcode/japan_post.rb
+++ b/lib/jipcode/japan_post.rb
@@ -7,8 +7,8 @@ require 'nkf'
 module Jipcode
   module JapanPost
     ZIPCODE_URLS = {
-      general: 'https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip'.freeze,
-      company: 'https://www.post.japanpost.jp/zipcode/dl/jigyosyo/zip/jigyosyo.zip'.freeze
+      general: 'https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip'.freeze,
+      company: 'https://www.post.japanpost.jp/service/search/zipcode/download/office/zip/jigyosyo.zip'.freeze
     }.freeze
     ZIPCODE_FILES = {
       general: 'KEN_ALL.CSV'.freeze,

--- a/spec/fixtures/vcr_cassettes/japan_post_zipcodes.yml
+++ b/spec/fixtures/vcr_cassettes/japan_post_zipcodes.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip
+    uri: https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip
     body:
       encoding: US-ASCII
       string: ''
@@ -19,34 +19,36 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 25 Mar 2018 04:56:23 GMT
-      Server:
-      - Apache
+      - Fri, 22 May 2026 12:36:05 GMT
+      Content-Type:
+      - application/zip
+      Content-Length:
+      - '1694716'
+      Connection:
+      - keep-alive
       X-Frame-Options:
       - SAMEORIGIN
       X-Content-Type-Options:
       - nosniff
       Last-Modified:
-      - Wed, 28 Feb 2018 07:59:01 GMT
+      - Fri, 01 May 2026 03:11:52 GMT
+      X-Durasiteedge-Cache:
+      - HIT
+      Expires:
+      - Fri, 22 May 2026 13:36:05 GMT
+      Cache-Control:
+      - max-age=3600
       Accept-Ranges:
       - bytes
-      Content-Type:
-      - application/zip
-      Content-Length:
-      - '1686611'
-      Proxy-Connection:
-      - Keep-Alive
-      Connection:
-      - Keep-Alive
-      Age:
-      - '904'
+      Server:
+      - Accelia
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-  recorded_at: Sun, 25 Mar 2018 05:11:27 GMT
+  recorded_at: Fri, 22 May 2026 12:36:05 GMT
 - request:
     method: get
-    uri: https://www.post.japanpost.jp/zipcode/dl/jigyosyo/zip/jigyosyo.zip
+    uri: https://www.post.japanpost.jp/service/search/zipcode/download/office/zip/jigyosyo.zip
     body:
       encoding: US-ASCII
       string: ''
@@ -63,30 +65,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 25 Mar 2018 04:56:24 GMT
-      Server:
-      - Apache
+      - Fri, 22 May 2026 12:36:05 GMT
+      Content-Type:
+      - application/zip
+      Content-Length:
+      - '775090'
+      Connection:
+      - keep-alive
       X-Frame-Options:
       - SAMEORIGIN
       X-Content-Type-Options:
       - nosniff
       Last-Modified:
-      - Wed, 28 Feb 2018 07:59:01 GMT
+      - Fri, 01 May 2026 03:26:46 GMT
+      X-Durasiteedge-Cache:
+      - HIT
+      Expires:
+      - Fri, 22 May 2026 13:36:05 GMT
+      Cache-Control:
+      - max-age=3600
       Accept-Ranges:
       - bytes
-      Content-Type:
-      - application/zip
-      Content-Length:
-      - '759923'
-      Proxy-Connection:
-      - Keep-Alive
-      Connection:
-      - Keep-Alive
-      Age:
-      - '903'
+      Server:
+      - Accelia
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-    http_version:
-  recorded_at: Sun, 25 Mar 2018 05:11:27 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Fri, 22 May 2026 12:36:05 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
URL変更して、4月のデータ更新をrevertしてやり直しに成功した。